### PR TITLE
Firefoxに対応

### DIFF
--- a/firefox.js
+++ b/firefox.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var self = require('sdk/self');
+var PageMod = require('sdk/page-mod').PageMod;
+
+PageMod({
+  include: /^https:\/\/moodle-cloud\.ealps\.shinshu-u\.ac\.jp\/.+\/resource\/view\.php\?id=.*$/,
+  contentScriptFile: self.data.url('main.js').replace('/data/', '/')
+});
+
+function main(options, callbacks) {
+}
+
+function onUnload(reason) {
+}
+
+exports.main = main;
+exports.onUnload = onUnload;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "title": "eALPS PDF Viewer",
+  "name": "ealps-pdf-viewer",
+  "version": "1.0.0",
+  "description": "信州大学eALPSのPDFを標準ビュワーで開く",
+  "main": "firefox.js",
+  "author": "",
+  "engines": {
+    "firefox": ">=38.0a1"
+  },
+  "license": ""
+}


### PR DESCRIPTION
`jpm xpi`でFirefoxのアドオンとしても読み込めるようにしました
[jpmの使い方](https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Getting_Started_%28jpm%29)
